### PR TITLE
Typings fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ Fluent assertions library extracted from [pavlov](https://github.com/mmonteleone
 $ npm install --save-dev pavlov-assert
 ```
 
-If you are using typescript, you can install the type definitions with [`typings`](https://github.com/typings/typings):
-
-```sh
-$ typings install --save-dev npm:pavlov-assert
-```
+If you are using typescript, type definitions will be automatically provided.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Fluent assertions library extracted from [pavlov](https://github.com/mmonteleone
 $ npm install --save-dev pavlov-assert
 ```
 
+If you are using typescript, you can install the type definitions with [`typings`](https://github.com/typings/typings):
+
+```sh
+$ typings install --save-dev npm:pavlov-assert
+```
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "^2.4",
     "mocha-testdata": "^1.1",
     "tslint": "^3.6",
-    "typescript": "^1.8"
+    "typescript": "^1.8",
+    "typings": "^0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "git+https://github.com/pandell/pavlov-assert.git"
   },
-  "typescript": {
-    "definition": "dist/assert.d.ts"
-  },
   "author": {
     "name": "Pandell",
     "url": "http://pandell.com/"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Fluent assertions",
   "license": "MIT",
   "main": "dist/assert.js",
+  "typings": "dist/assert.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pandell/pavlov-assert.git"

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,7 @@
 {
-  "version": false,
+  "name": "pavlov-assert",
+  "version": "^1.0",
+  "main": "dist/assert.d.ts",
   "dependencies": {},
   "ambientDevDependencies": {
     "mocha": "registry:dt/mocha#2.2.5+20151023103246",

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,6 @@
 {
   "name": "pavlov-assert",
-  "version": "^1.0",
-  "main": "dist/assert.d.ts",
+  "version": false,
   "dependencies": {},
   "ambientDevDependencies": {
     "mocha": "registry:dt/mocha#2.2.5+20151023103246",


### PR DESCRIPTION
As per the [`typings` docs](https://github.com/typings/typings/blob/master/docs/faq.md#should-i-use-the-typings-field-in-packagejson), typing metadata should live in `typings.json`, rather than `package.json`.

It probably doesn't matter too much for this repository since there are no dependencies, but this change is more for consistency.
