### PR TITLE
Add "clobber" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pavlov"
   ],
   "scripts": {
+    "clobber": "git -c core.longpaths=true clean -dfX",
     "build": "npm run lint && tsc",
     "lint": "tslint src/*.ts",
     "prepublish": "typings install && npm run build",


### PR DESCRIPTION
Completely removes npm and build artifacts, keeping only source-controlled and new files (files that have not been explicitly excluded using ".gitignore").

This is a heads-up pull request, will be merged shortly.
